### PR TITLE
updated README for Core ML section

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,10 @@ EdgeTAM can be exported to CoreML format for deployment on iOS and macOS devices
 
 ```bash
 # Export EdgeTAM to CoreML format
-python ./tools/export_to_coreml.py \
-  --sam2_cfg configs/edgetam.yaml \
+python ./coreml/export_to_coreml.py \
+  --sam2_cfg ./sam2/configs/edgetam.yaml \
   --sam2_checkpoint ./checkpoints/edgetam.pt \
-  --output_dir ./coreml_models \
-  --validate
+  --output_dir ./coreml_models
 ```
 
 This creates three optimized CoreML models:


### PR DESCRIPTION
Fixes #21. The documentation for the CoreML export command was outdated

This PR updates the README.md to correct the command lines for CoreML Export. The previous instructions contained incorrect file paths for both the export script and the configuration file.

Changes:
✅Corrected script path from `./tools/export_to_coreml.py` to `./coreml/export_to_coreml.py.`
✅Updated configuration path to `./sam2/configs/edgetam.yaml`.
✅Removed the `--validate` flag to match current usage.